### PR TITLE
media-kit: add trans colored variants of the nix logo

### DIFF
--- a/package-sets/python-packages/nixoslogo/nixoslogo/core.py
+++ b/package-sets/python-packages/nixoslogo/nixoslogo/core.py
@@ -89,6 +89,7 @@ with open(get_nixos_color_palette_file(), "rb") as f:
 
 PALETTE_DEFAULT_COLORS = NIXOS_COLOR_PALETTE["logos"]["default"]
 PALETTE_RAINBOW_COLORS = NIXOS_COLOR_PALETTE["logos"]["rainbow"]
+PALETTE_TRANS_COLORS = NIXOS_COLOR_PALETTE["logos"]["trans"]
 PALETTE_PRIMARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["primary"]
 PALETTE_SECONDARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["secondary"]
 PALETTE_ACCENT_COLORS = NIXOS_COLOR_PALETTE["palette"]["accent"]
@@ -107,6 +108,13 @@ RAINBOW_COLORS = tuple(
         PALETTE_RAINBOW_COLORS,
     )
 )
+TRANS_COLORS = tuple(
+    map(
+        lambda color: Color("oklch", color["value"]),
+        PALETTE_TRANS_COLORS,
+    )
+)
+
 NIXOS_BLACK = Color(
     "oklch",
     get_color_by_name(PALETTE_PRIMARY_COLORS, "Black")["value"],
@@ -140,6 +148,7 @@ class LogoLayout(Enum):
 class LogomarkColors(Enum):
     DEFAULT = (NIXOS_DARK_BLUE, NIXOS_LIGHT_BLUE)
     RAINBOW = RAINBOW_COLORS
+    TRANS = TRANS_COLORS
     BLACK = (NIXOS_BLACK,)
     WHITE = (NIXOS_WHITE,)
 

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-horizontal-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-horizontal-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-horizontal-none";
+  outputHash = "sha256-cKUxz93fQ/UXYZLzTIw2XDkFmemihoPBRZqcv350gWk=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-horizontal-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-horizontal-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-vertical-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-vertical-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-vertical-none";
+  outputHash = "sha256-i0sqj250GXONVe4N7+AlolAhzoNlGFisfbau3nWoj8w=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-vertical-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-trans-gradient-white-regular-vertical-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-flat-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-flat-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-flat-none";
+  outputHash = "sha256-aip6Suw+1p25IMhJyN8KAxYrzy92gY4g8kq74wwp30Y=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-flat-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-flat-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-gradient-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-gradient-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-gradient-none";
+  outputHash = "sha256-x3dA6rPK2dnR9dZMLlIkDFChETGKv3rsfKl/gCZzDA4=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-gradient-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-trans-gradient-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-horizontal-minimal";
+  outputHash = "sha256-W4JJ2Cwioz7hc6mAQUMGuodAcjw6Xbf6y7u0CvR1IDg=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-horizontal-recommended";
+  outputHash = "sha256-EmJLrzTjeKN/ydSn/ue76eewYqJn564rhvQ/nfzyOhs=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-horizontal-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-vertical-minimal";
+  outputHash = "sha256-0JY3h764F34kcStKEhMiGpAYkK4RJN+8+18/tw2Z8LA=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-trans-gradient-white-regular-vertical-recommended";
+  outputHash = "sha256-owbjMRYoSL/gLCgQe3afYl0OH97gR/8V3v78vYgr4JE=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-trans-gradient-white-regular-vertical-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.TRANS,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-flat-minimal";
+  outputHash = "sha256-CO56eHjs1PGlYGa07Tu0oitkJpp7047yd78zbAFBYhM=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-flat-recommended";
+  outputHash = "sha256-ogdV5Tt3mv2pYKAOfxhEv4meL10NigujKA22QkyRz1M=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-flat-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-gradient-minimal";
+  outputHash = "sha256-lcCQ+v4NVnQzQbGSLRj9a91kKEpYvEZIhvLnYxPX40k=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-trans-gradient-recommended";
+  outputHash = "sha256-luMbAS8Qr2y/FkKdckvFlT1pIsi97AmKglw++lEz6JE=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-trans-gradient-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.TRANS,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
+++ b/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
@@ -33,6 +33,18 @@ value = [0.60, 0.141400, 241.380]
 name = "violet"
 value = [0.46, 0.194300, 288.710]
 
+[[logos.trans]]
+name = "pink"
+value = [0.81179, 0.09118, 6.3234]
+
+[[logos.trans]]
+name = "white"
+value = [1, 0, 0]
+
+[[logos.trans]]
+name = "blue"
+value = [0.8025, 0.12028, 226.51]
+
 [palette]
 [[palette.primary]]
 name = "Black"


### PR DESCRIPTION
When I asked @infinisil to use a trans flag colored variant of the nix logo for the [name plates](https://discourse.nixos.org/t/nixcon-2025-name-plates-anyone/67439), he asked me to submit the logo to the branding repo, so here it is!

On another note, my PR does not add the new logo variant to the branding guide. In case it should also be added there, please let me know and I'll see about including that in this PR.