### PR TITLE
fix: remove comma in oklch values

### DIFF
--- a/package-sets/top-level/nixos-branding/npm-package/package.nix
+++ b/package-sets/top-level/nixos-branding/npm-package/package.nix
@@ -71,7 +71,7 @@ let
 
   toKebapCase = x: toLower (replaceStrings [ " " ] [ "-" ] x);
 
-  arrToOklch = arr: "oklch(${concatMapStringsSep ", " toString arr})";
+  arrToOklch = arr: "oklch(${concatMapStringsSep " " toString arr})";
 
   colorsFile = importTOML ../nixos-color-palette/colors.toml;
 


### PR DESCRIPTION
Commas in the tailwind oklch string are not correct.
The format should be `"oklch(0.150000 0.030000 330)"` and not `"oklch(0.150000, 0.030000, 330)"`.