### PR TITLE
artifact-builder: use testers.invalidateFetcherByDrvHash to ensure output hash validity

### DIFF
--- a/package-sets/top-level/nixos-branding/artifact-builder/package.nix
+++ b/package-sets/top-level/nixos-branding/artifact-builder/package.nix
@@ -1,38 +1,39 @@
-# artifact-builder
 {
   jura,
   nixos-color-palette,
   python3,
   route159,
   runCommandLocal,
+  testers,
 }:
-# artifact
-{
-  name,
-  outputHash,
-  script,
-}:
-runCommandLocal name
+testers.invalidateFetcherByDrvHash (
   {
-    inherit script;
+    name,
+    outputHash,
+    script,
+  }:
+  runCommandLocal name
+    {
+      inherit script;
 
-    nativeBuildInputs = [
-      (python3.withPackages (ps: [ ps.nixoslogo ]))
-    ];
+      nativeBuildInputs = [
+        (python3.withPackages (ps: [ ps.nixoslogo ]))
+      ];
 
-    outputHash = outputHash;
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
+      outputHash = outputHash;
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
 
-    env = {
-      NIXOS_ANNOTATIONS_FONT_FILE = "${jura}/share/fonts/truetype/jura/Jura-Regular.ttf";
-      NIXOS_COLOR_PALETTE_FILE = "${nixos-color-palette}/colors.toml";
-      NIXOS_LOGOTYPE_FONT_FILE = "${route159}/share/fonts/opentype/route159/Route159-Regular.otf";
-    };
+      env = {
+        NIXOS_ANNOTATIONS_FONT_FILE = "${jura}/share/fonts/truetype/jura/Jura-Regular.ttf";
+        NIXOS_COLOR_PALETTE_FILE = "${nixos-color-palette}/colors.toml";
+        NIXOS_LOGOTYPE_FONT_FILE = "${route159}/share/fonts/opentype/route159/Route159-Regular.otf";
+      };
 
-  }
-  ''
-    python $script
-    mkdir $out
-    cp *.svg $out/
-  ''
+    }
+    ''
+      python $script
+      mkdir $out
+      cp *.svg $out/
+    ''
+)


### PR DESCRIPTION
As discussed at NixCon, now a simple building of the drvs will check that the output hashes are all correct!