### PR TITLE
meta: add licensing, attribution, and provenance documentation

### DIFF
--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/Jura-OFL-1.1.txt
+++ b/LICENSES/Jura-OFL-1.1.txt
@@ -1,0 +1,92 @@
+Copyright Cyreal (https://github.com/cyrealtype)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,24 @@
+Valid-License-Identifier: MIT
+License-Text:
+
+MIT License
+
+Copyright (c) 2019 The nixos-homepage contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/Route159-OFL-1.1.txt
+++ b/LICENSES/Route159-OFL-1.1.txt
@@ -1,0 +1,93 @@
+Copyright (c) 2015, Sora Sagano (sagano@dotcolon.net)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,20 @@ See [`LICENSES/MIT.txt`](LICENSES/MIT.txt) for full terms.
 Creative works — including the NixOS logos, logotypes, color palettes, and related design files — are licensed under the **Creative Commons Attribution 4.0 International License (CC BY 4.0)**.
 See [`LICENSES/CC-BY-4.0.txt`](LICENSES/CC-BY-4.0.txt) or <https://creativecommons.org/licenses/by/4.0/>.
 
+### Fonts
+
+- Jura font by
+  Alexei Vanyashin, Daniel Johnson, Guldana Tauasar (Cyrillic), and Irene Vlachou (Greek)
+  from [alexeiva/jura](https://github.com/alexeiva/jura)
+  licensed under **SIL Open Font License, Version 1.1 (OFL-1.1)**.
+  See [`LICENSES/Jura-OFL-1.1.txt`](LICENSES/Jura-OFL-1.1.txt) or <https://openfontlicense.org/> for full terms.
+
+- Route 159 font
+  by Sora Sagano
+  from [dotcolon](https://www.dotcolon.net/fonts/route159/)
+  licensed under **SIL Open Font License, Version 1.1 (OFL-1.1)**.
+  See [`LICENSES/Route159-OFL-1.1.txt`](LICENSES/Route159-OFL-1.1.txt) or <https://openfontlicense.org/> for full terms.
+
 ### Attribution for NixOS Branding Assets
 
 The NixOS branding assets may be shared and adapted for any purpose, including commercial use, provided that you:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,54 @@ It can also be used with the `--rebuild` flag.
 nix run .\#nixos-branding.verification.verify-nixos-branding-all
 ```
 
+## License and Attribution
+
+This repository contains both **software code** and **design assets** used for the NixOS visual identity.
+
+### Code
+
+Source code files (for example, `.py` and `.nix` files) are licensed under the **MIT License**.
+See [`LICENSES/MIT.txt`](LICENSES/MIT.txt) for full terms.
+
+### Design Assets
+
+Creative works — including the NixOS logos, logotypes, color palettes, and related design files — are licensed under the **Creative Commons Attribution 4.0 International License (CC BY 4.0)**.
+See [`LICENSES/CC-BY-4.0.txt`](LICENSES/CC-BY-4.0.txt) or <https://creativecommons.org/licenses/by/4.0/>.
+
+### Attribution for NixOS Branding Assets
+
+The NixOS branding assets may be shared and adapted for any purpose, including commercial use, provided that you:
+
+- Give appropriate credit to the **NixOS Project** and contributors.
+- Provide a link to the license.
+- Indicate if changes were made.
+
+Please use the **TASL format** (Title, Author, Source, License) for attribution. For example:
+
+> “NixOS Logo” by [Simon Frankau](https://github.com/simon-frankau),
+> [Tim Cuthbertson](https://github.com/timbertson),
+> and [Daniel Baker](https://github.com/djacu)
+> (maintained by the [NixOS Marketing Team](https://nixos.org/community/teams/marketing/)),
+> from [nixos/branding](https://github.com/NixOS/branding),
+> licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+
+### Logo Attribution
+
+The NixOS logo has evolved through several community revisions:
+
+- **Original design** by [Simon Frankau (@simon-frankau)](https://github.com/simon-frankau)\
+  [View commit → d5af1e3971822b8a3ec19689a17464558baf7244](https://github.com/NixOS/nixos-homepage/commit/d5af1e3971822b8a3ec19689a17464558baf7244)
+- **Revision** by [Tim Cuthbertson (@timbertson)](https://github.com/timbertson)\
+  [View pull request → #55](https://github.com/NixOS/nixos-homepage/pull/55)
+- **Further revision** by [Daniel Baker (@djacu)](https://github.com/djacu)\
+  [View pull request → #1](https://github.com/NixOS/branding/pull/1)
+
+All versions are licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+> For historical licensing correspondence, see
+> [`docs/provenance/`](docs/provenance/) for records confirming continued
+> permission to use and modify the NixOS logo under CC BY 4.0.
+
 ## Contact
 
 For questions, feedback, or to request approval for brand use, reach out to the [NixOS Marketing Team](https://nixos.org/community/teams/marketing/).

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -1,0 +1,48 @@
+# Provenance Documentation
+
+This directory contains correspondence and records verifying the authorship,
+permissions, and licensing history of the NixOS logo.
+
+Each entry documents a conversation confirming that the logo may be distributed
+and modified under the **Creative Commons Attribution 4.0 International License
+(CC BY 4.0)**.
+
+These records ensure the license chain for the NixOS logo remains verifiable and
+transparent across its historical revisions.
+
+______________________________________________________________________
+
+## Files
+
+### `nixos-logo-permission-20161002-cuthbertson.txt`
+
+Public mailing list discussion between **Tim Cuthbertson** and the NixOS
+community (October 2016). In this thread, Tim confirms that the NixOS logo is
+released under the **CC BY** license and may be freely used or modified,
+provided attribution is preserved and changes are noted. Original archive link:
+<https://releases.nixos.org/nix-dev/2016-October/021876.html>
+
+### `nixos-logo-permission-20250917-cuthbertson.txt`
+
+Private email correspondence between **Daniel Baker**, **Eelco Dolstra**, and
+**Tim Cuthbertson** (September 2025). Daniel requested confirmation to continue
+licensing the NixOS logo under **CC BY 4.0** for the modern branding repository.
+Eelco agreed while clarifying he was not the logo’s creator; Tim confirmed his
+consent (“Also fine with me 👍”). This exchange serves as formal acknowledgment
+of continued permission for the NixOS logo under the same license.
+
+______________________________________________________________________
+
+## Privacy Notice
+
+All personal email addresses have been redacted. Unredacted copies of private
+correspondence are securely retained by **Daniel Baker** for provenance
+verification.
+
+Publicly archived discussions (e.g., the 2016 mailing list thread) are linked
+rather than redistributed in full, though key excerpts are vendored here for
+long-term reference.
+
+______________________________________________________________________
+
+_Last updated: 2025-10-05_

--- a/docs/provenance/README.md
+++ b/docs/provenance/README.md
@@ -31,6 +31,13 @@ Eelco agreed while clarifying he was not the logo’s creator; Tim confirmed his
 consent (“Also fine with me 👍”). This exchange serves as formal acknowledgment
 of continued permission for the NixOS logo under the same license.
 
+### `jura-font-attribution-20251013-cyreal.txt`
+
+Email exchange between **Alexei Vanyashin (Cyreal)** and **Daniel Baker**
+confirming the correct authorship and license attribution for the **Jura**
+font used in NixOS branding.
+Confirms SIL Open Font License (OFL 1.1) and attribution formatting.
+
 ______________________________________________________________________
 
 ## Privacy Notice
@@ -45,4 +52,4 @@ long-term reference.
 
 ______________________________________________________________________
 
-_Last updated: 2025-10-05_
+_Last updated: 2025-12-01_

--- a/docs/provenance/jura-font-attribution-20251013-cyreal.txt
+++ b/docs/provenance/jura-font-attribution-20251013-cyreal.txt
@@ -1,0 +1,103 @@
+# Jura Font Attribution Confirmation (Alexei Vanyashin, Cyreal, 2025)
+# ------------------------------------------------------------------------------
+# Private email correspondence between Alexei Vanyashin (Cyreal) and
+# Daniel Baker regarding the correct authorship attribution for the
+# Jura font used in the NixOS branding repository.
+#
+# Summary:
+#   In this October 2025 exchange, Daniel Baker of the NixOS Marketing Team
+#   contacted Alexei Vanyashin of Cyreal to confirm the correct attribution
+#   and licensing for the Jura font, which is included in the repository
+#   under the SIL Open Font License (OFL) version 1.1.
+#
+#   Alexei confirmed that the attribution as drafted was mostly correct and
+#   suggested including the language-specific contributors in parentheses:
+#   “Jura font by Alexei Vanyashin, Daniel Johnson, Guldana Tauasar
+#   (Cyrillic), and Irene Vlachou (Greek)”. He also confirmed the correct
+#   license and repository source, and offered to produce a customized
+#   version of Jura (“Nix Sans”) for the NixOS project if desired.
+#
+# Privacy:
+#   Personal email addresses have been redacted. The unredacted message is
+#   retained privately by Daniel Baker for provenance verification.
+#
+# Provenance links:
+#   Jura repository: https://github.com/alexeiva/jura
+#   License text:    https://openfontlicense.org/
+#
+# Full message thread (redacted for privacy):
+
+------------------------------------------------------------------------------
+From: Daniel Baker <[REDACTED]>
+Date: Wed, 8 Oct 2025 23:15:00 -0700
+Subject: attribution of Jura font
+To: Alexei Vanyashin <[REDACTED]>
+
+Hey Alexei,
+
+I am on the Marketing Team for the NixOS project. I recently released a
+branding guide for the project that uses the Jura font
+(https://brand.nixos.org/documents/nixos-branding-guide.pdf). I am
+vendoring the font in our branding repository
+(https://github.com/NixOS/branding/tree/d1b5e1c99e44cd74bb335c3e66c52f39082da264/package-sets/top-level/jura).
+
+It is a really great font and I want to attribute the authors
+appropriately. I am working on a pull request to add licensing and
+attribution information to the repository
+(https://github.com/NixOS/branding/pull/29). I am having trouble with a
+couple issues and am hoping you can help me out.
+
+- Which is the most up-to-date version of the font? Which would you
+  recommend I use?
+- What would be the appropriate way to attribute the font?
+
+The Cyreal website lists the following people as authors:
+  Alexei Vanyashin
+  Daniel Johnson
+  Guldana Tauasar
+  Irene Vlachou
+
+I am considering adding the following to our README for attribution:
+
+Jura font by
+Alexei Vanyashin, Daniel Johnson, Guldana Tauasar, and Irene Vlachou
+from [alexeiva/jura](https://github.com/alexeiva/jura)
+licensed under [SIL Open Font License, Version 1.1]
+(https://openfontlicense.org/).
+
+Thanks in advance for your help.
+
+All the best,  
+Daniel Baker
+
+------------------------------------------------------------------------------
+From: Alexei Vanyashin <[REDACTED]>
+Date: Mon, 13 Oct 2025 18:01:37 +0300
+Subject: Re: attribution of Jura font
+To: Daniel Baker <[REDACTED]>
+
+Hello Daniel,
+
+Thank you for reaching out! I would be glad to add the news to our
+OpenCollective feed (https://opencollective.com/cyreal).
+
+The attribution is mostly correct. I would suggest adding Cyrillic and
+Greek authors in parentheses like so:
+
+Jura font by
+Alexei Vanyashin, Daniel Johnson, Guldana Tauasar (Cyrillic),
+and Irene Vlachou (Greek)
+from [alexeiva/jura](https://github.com/alexeiva/jura)
+licensed under [SIL Open Font License, Version 1.1]
+(https://openfontlicense.org/).
+
+Would you like a customized version of Jura for NixOS? The font can be
+tailored to your specific needs, shipped as “Nix Sans” for a reasonable
+fee. Would be happy to discuss this further.
+
+Best,  
+Alexei
+------------------------------------------------------------------------------
+
+# End of correspondence
+

--- a/docs/provenance/nixos-logo-permission-20161002-cuthbertson.txt
+++ b/docs/provenance/nixos-logo-permission-20161002-cuthbertson.txt
@@ -1,0 +1,42 @@
+# NixOS Logo Permission (Tim Cuthbertson, 2016)
+# ----------------------------------------------------------------------------
+# Public mailing list discussion archived at:
+# https://releases.nixos.org/nix-dev/2016-October/021876.html
+#
+# Summary:
+#   In this thread, Tim Cuthbertson responded to a request about the Nix logo
+#   license and confirmed that he is okay with the logo being licensed under
+#   CC BY. He wrote that CC BY had already been suggested, and expressed his
+#   willingness to go along with whatever the Nix project preferred. He also
+#   offered that, if desired, he could transfer or assign copyright in a way
+#   that credits a project entity (for example, the Nix Foundation) rather
+#   than himself.
+#
+# Full message excerpt (vendored for preservation):
+
+------------------------------------------------------------------------------
+Hi all,
+
+Thomasz recently asked about the Nix logo license, and when I searched I
+noticed there had been another question about this a few months ago on the
+mailing list (which I missed).
+
+Apologies for not addressing this sooner, I agree that we should be explicit
+about the logo license. I'm happy to go along with pretty much whatever the
+nix project prefers (CC-BY has already been suggested), and if there's some
+official nix project entity which could be credited, I'd be happy to assign
+copyright there too (so you could just credit e.g. the nix foundation, not me
+specifically).
+
+@edolstra: are you happy with a CC-BY license for the logo? I'm holding off
+from _actually_ declaring it yet in case you'd prefer to restrict derivatives
+or something, but if I don't hear back from you within a week I'll assume that
+CC-BY is fine :). And if you are happy with CC-BY, could you go ahead and
+declare that on the website / repo somewhere so we have it in writing for
+anyone else that comes looking?
+
+Cheers,
+- Tim.
+------------------------------------------------------------------------------
+
+# End of excerpt

--- a/docs/provenance/nixos-logo-permission-20250917-cuthbertson.txt
+++ b/docs/provenance/nixos-logo-permission-20250917-cuthbertson.txt
@@ -1,0 +1,90 @@
+# NixOS Logo Permission (Tim Cuthbertson, Eelco Dolstra, Daniel Baker, 2025)
+# ------------------------------------------------------------------------------
+# Private email correspondence between Tim Cuthbertson, Eelco Dolstra, and
+# Daniel Baker regarding the continued use and licensing of the NixOS logo.
+#
+# Summary:
+#   In this 2025 email thread, Daniel Baker contacted Tim Cuthbertson and
+#   Eelco Dolstra to confirm that the NixOS logo, as maintained in the
+#   branding repository, could continue under the Creative Commons
+#   Attribution (CC BY) license that had been discussed in the 2016 mailing
+#   list thread.
+#
+#   Eelco replied that he was fine with the arrangement but clarified that
+#   he did not create the logo. Tim followed up confirming his agreement
+#   with the CC BY license ("Also fine with me 👍"). This exchange records
+#   the authors’ mutual consent to carry forward the CC BY license for the
+#   current version of the NixOS logo.
+#
+# Privacy:
+#   Personal email addresses have been redacted. The full unredacted
+#   correspondence is retained privately by Daniel Baker.
+#
+# Provenance links:
+#   Related 2016 public mailing list discussion:
+#   https://releases.nixos.org/nix-dev/2016-October/021876.html
+#
+# Full message excerpt (redacted for privacy):
+
+------------------------------------------------------------------------------
+From: Daniel Baker <[REDACTED]>
+Date: Wed, 17 Sep 2025 22:22:43 -0700
+Subject: NixOS Logo license
+To: Tim Cuthbertson <[REDACTED]>, Eelco Dolstra <[REDACTED]>
+
+Hi Tim and Eelco,
+
+Not sure if either of you have been keeping up with the NixOS Marketing
+Team's activities but we have a whole new branding repository and an update
+on Tim's design.
+
+https://github.com/nixos/branding
+
+I'd like to continue the CC-BY license that was mentioned in this email
+thread.
+https://releases.nixos.org/nix-dev/2016-October/021881.html
+
+Would it be alright with the both of you?
+
+Regards,
+Daniel
+
+------------------------------------------------------------------------------
+From: Eelco Dolstra <[REDACTED]>
+Date: Thu, 18 Sep 2025 18:46:00 +1000
+Subject: Re: NixOS Logo license
+To: Daniel Baker <[REDACTED]>
+Cc: Tim Cuthbertson <[REDACTED]>
+
+Hi Daniel,
+
+On 9/18/25 07:22, Daniel Baker wrote:
+
+> Not sure if either of you have been keeping up with the NixOS Marketing
+> Team's activities but we have a whole new branding repository and an
+> update on Tim's design.
+>
+> https://github.com/nixos/branding
+>
+> I'd like to continue the CC-BY license that was mentioned in this email
+> thread.
+> https://releases.nixos.org/nix-dev/2016-October/021881.html
+>
+> Would it be alright with the both of you?
+
+Fine with me, but to be clear, I didn't create the logo.
+
+--
+Eelco Dolstra | http://nixos.org/~eelco/
+
+------------------------------------------------------------------------------
+From: Tim Cuthbertson <[REDACTED]>
+Date: Thu, 18 Sep 2025 19:14:22 +1000
+Subject: Re: NixOS Logo license
+To: Eelco Dolstra <[REDACTED]>
+Cc: Daniel Baker <[REDACTED]>
+
+Also fine with me 👍
+------------------------------------------------------------------------------
+
+# End of correspondence


### PR DESCRIPTION
- Added root LICENSE file referencing MIT (for code) and CC BY 4.0 (for assets)
- Added LICENSES/ directory containing:
  - CC-BY-4.0.txt (Creative Commons Attribution 4.0 International)
  - MIT.txt (MIT License for code and generators)
  - Jura-OFL-1.1.txt (SIL Open Font License)
  - Route159-OFL-1.1.txt (SIL Open Font License)
- Added docs/provenance/ directory with:
  - nixos-logo-permission-20161002-cuthbertson.txt (2016 CC BY confirmation)
  - nixos-logo-permission-20250917-cuthbertson.txt (2025 CC BY confirmation)
  - jura-font-attribution-20251013-cyreal.txt (SIL OFL confirmation)
  - README.md summarizing provenance and privacy handling
- Updated repository README.md to include:
  - License and Attribution sections
  - Detailed Logo Attribution with author handles and canonical links
  - Provenance reference to docs/provenance/

This establishes a transparent, verifiable license chain for the NixOS logo and other branding assets, preserving historical authorship and compliance with CC BY 4.0 and MIT license requirements.

resolves #13 