### PR TITLE
feat: add Ukranians branding derivations

### DIFF
--- a/package-sets/python-packages/nixoslogo/nixoslogo/core.py
+++ b/package-sets/python-packages/nixoslogo/nixoslogo/core.py
@@ -93,6 +93,7 @@ PALETTE_TRANS_COLORS = NIXOS_COLOR_PALETTE["logos"]["trans"]
 PALETTE_PRIMARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["primary"]
 PALETTE_SECONDARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["secondary"]
 PALETTE_ACCENT_COLORS = NIXOS_COLOR_PALETTE["palette"]["accent"]
+PALETTE_UKRAINE_COLORS = NIXOS_COLOR_PALETTE["logos"]["ukraine"]
 
 NIXOS_DARK_BLUE = Color(
     "oklch",
@@ -112,6 +113,12 @@ TRANS_COLORS = tuple(
     map(
         lambda color: Color("oklch", color["value"]),
         PALETTE_TRANS_COLORS,
+    )
+)
+UKRAINE_COLORS = tuple(
+    map(
+        lambda color: Color("oklch", color["value"]),
+        PALETTE_UKRAINE_COLORS,
     )
 )
 
@@ -151,6 +158,7 @@ class LogomarkColors(Enum):
     TRANS = TRANS_COLORS
     BLACK = (NIXOS_BLACK,)
     WHITE = (NIXOS_WHITE,)
+    UKRAINE = UKRAINE_COLORS
 
 
 class LogotypeStyle(Enum):

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-flat-black-regular-vertical-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-flat-black-regular-vertical-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-flat-black-regular-vertical-none";
+  outputHash = "sha256-EHQ0Q86uNMoCgexIlvZh+CoV2sFmH8CgK9atWhPGl04=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-flat-black-regular-vertical-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-flat-black-regular-vertical-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.BLACK,
+    logomark_color_style=ColorStyle.FLAT,
+    logotype_color="black",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-horizontal-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-horizontal-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-horizontal-none";
+  outputHash = "sha256-kr6j7hR3Nx4vrRqjQz3pVBGY2+9+EhxXaq8RPky3Ugs=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-horizontal-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-horizontal-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-vertical-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-vertical-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-vertical-none";
+  outputHash = "sha256-3j/doatux/FGCqdlq6o+arYNFLu7rvyhGH4UJ3lbGjg=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-vertical-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-ukraine-gradient-white-regular-vertical-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-flat-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-flat-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-flat-none";
+  outputHash = "sha256-rCaYxn/FlU8y/xoLKDrVPWcmKGTRlmauSwRUHnDMQKo=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-flat-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-flat-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-gradient-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-gradient-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-gradient-none";
+  outputHash = "sha256-5PgX2tKjNkZpYAnq/OOwt3J6o0C5R6+kCBSaUOZHtUw=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-gradient-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-ukraine-gradient-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-horizontal-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-horizontal-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-flat-black-regular-horizontal-recommended";
+  outputHash = "sha256-XVTihRfleyhD6HAHrLzo8ckZ9O8vkoFzoWRUUxkE2vo=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-horizontal-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-horizontal-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.BLACK,
+    logomark_color_style=ColorStyle.FLAT,
+    logotype_color="black",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-vertical-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-vertical-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-flat-black-regular-vertical-minimal";
+  outputHash = "sha256-ehDKqLNh/Oijv5fmMTuM0CEBRmM+tvxGTypl/p1Nouc=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-vertical-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-flat-black-regular-vertical-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.BLACK,
+    logomark_color_style=ColorStyle.FLAT,
+    logotype_color="black",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-black-regular-horizontal-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-black-regular-horizontal-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-black-regular-horizontal-recommended";
+  outputHash = "sha256-IfTBcsR0Yv5B9oZ7vjXff4rFLbOV9/NWjWs+0Xh8md4=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-black-regular-horizontal-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-black-regular-horizontal-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="black",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-horizontal-minimal";
+  outputHash = "sha256-T33BjNZNE00HTdz8hCpDeAvgxswW8Oi8GX/MZMHRnq4=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-horizontal-recommended";
+  outputHash = "sha256-dsirX1x+GYozTRqHut+oBY/esLGN8n9NcJ5o4DCoLEA=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-vertical-minimal";
+  outputHash = "sha256-Lfe4VpiND9r9irV1cde3gdySMPCGexNQ6iEl7cYNcHY=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-ukraine-gradient-white-regular-vertical-recommended";
+  outputHash = "sha256-tmd1CObJwzt1xH07zL94zCFIU9PF8a7e7mDqNeapzKs=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-ukraine-gradient-white-regular-vertical-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.UKRAINE,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-flat-minimal";
+  outputHash = "sha256-pOvPHO9BZCfX0Or8TBEoLgjOKZFsDRX5FePrt/I+3HM=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-flat-recommended";
+  outputHash = "sha256-1ANiqIfwsEXbem8HgiYxTsZ+t1E4fVNsAFMpGUF52FY=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-flat-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-gradient-minimal";
+  outputHash = "sha256-s9Zw4jbtwCdkAXh/Y0v4FZXIly5o7dQh5s7DNZPn0jk=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-ukraine-gradient-recommended";
+  outputHash = "sha256-mBrBQrrPSDnVBG1sGkZGDqN5cLVk3BSnh0HBvNMdUUs=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-ukraine-gradient-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.UKRAINE,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/nixos-branding-guide/nixos-branding-guide.typ
+++ b/package-sets/top-level/nixos-branding/nixos-branding-guide/nixos-branding-guide.typ
@@ -493,12 +493,17 @@
     content: [
       #grid(
         columns: (1fr, 1fr),
-        rows: (1fr, 1fr, 1fr),
-        gutter: 1em,
+        rows: (auto, 1fr) * 4,
+        gutter: .5em,
         align: center,
         [
           Default/Black
+        ],
+        [
+          Default/White
+        ],
 
+        [
           #imageBox(
             image(
               "./media-kit/nixos-logo-default-gradient-black-regular-horizontal-recommended.svg",
@@ -506,8 +511,6 @@
           )
         ],
         [
-          Default/White
-
           #imageBoxDark(
             image(
               "./media-kit/nixos-logo-default-gradient-white-regular-horizontal-recommended.svg",
@@ -517,7 +520,12 @@
 
         [
           Rainbow/Black
+        ],
+        [
+          Rainbow/White
+        ],
 
+        [
           #imageBox(
             image(
               "./media-kit/nixos-logo-rainbow-gradient-black-regular-horizontal-recommended.svg",
@@ -525,8 +533,6 @@
           )
         ],
         [
-          Rainbow/White
-
           #imageBoxDark(
             image(
               "./media-kit/nixos-logo-rainbow-gradient-white-regular-horizontal-recommended.svg",
@@ -535,8 +541,35 @@
         ],
 
         [
-          Black/Black
+          Ukraine/Black
+        ],
+        [
+          Ukraine/White
+        ],
 
+        [
+          #imageBox(
+            image(
+              "./media-kit/nixos-logo-ukraine-gradient-black-regular-horizontal-recommended.svg",
+            ),
+          )
+        ],
+        [
+          #imageBoxDark(
+            image(
+              "./media-kit/nixos-logo-ukraine-gradient-white-regular-horizontal-recommended.svg",
+            ),
+          )
+        ],
+
+        [
+          Black/Black
+        ],
+        [
+          White/White
+        ],
+
+        [
           #imageBox(
             image(
               "./media-kit/nixos-logo-black-flat-black-regular-horizontal-recommended.svg",
@@ -544,8 +577,6 @@
           )
         ],
         [
-          White/White
-
           #imageBoxDark(
             image(
               "./media-kit/nixos-logo-white-flat-white-regular-horizontal-recommended.svg",

--- a/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
+++ b/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
@@ -2,7 +2,7 @@ version = "0.1.0"
 
 [logos]
 [[logos.default]]
-name = "NixOS Dark Blue" 
+name = "NixOS Dark Blue"
 value = [0.55, 0.12, 264]
 
 [[logos.default]]
@@ -44,6 +44,14 @@ value = [1, 0, 0]
 [[logos.trans]]
 name = "blue"
 value = [0.8025, 0.12028, 226.51]
+
+[[logos.ukraine]]
+name = "Strong Azure"
+value = [0.473, 0.168, 257.0]
+
+[[logos.ukraine]]
+name = "Cyber Yellow"
+value = [0.877, 0.191, 85.9]
 
 [palette]
 [[palette.primary]]


### PR DESCRIPTION
Hello,

6 months ago, in [#1830](https://github.com/NixOS/nixos-homepage/issues/1830), I proposed to have a Ukrainian flag derivation for the NixOS logo.

There were some rumors that this proposal was just a way to get rid of the Rainbow logo that was in place at that time, those rumors are untrue.
 
Anyway, here's the branding derivations with Ukrainian colors, let me know if this is OK.

Preview:

<img width="1439" height="1022" alt="image" src="https://github.com/user-attachments/assets/b4432c0c-dacb-4750-9b14-1c5b6de820d6" />
