### PR TITLE
Harden release/check workflows against changelog shell injection

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -168,9 +168,11 @@ jobs:
           changelog: ./package-sets/top-level/nixos-branding/nixos-branding-guide/CHANGELOG.md
 
       - name: Display release info
+        env:
+          VERSION: ${{ steps.query-release-info.outputs.version }}
+          RELEASE_DATE: ${{ steps.query-release-info.outputs.release-date }}
+          NOTES: ${{ steps.query-release-info.outputs.release-notes }}
         run: |
-          echo "Version: ${{ steps.query-release-info.outputs.version }}"
-          echo "Date: ${{ steps.query-release-info.outputs.release-date }}"
-          cat <<'EOF'
-          "${{ steps.query-release-info.outputs.release-notes }}"
-          EOF
+          printf 'Version: %s\n' "$VERSION"
+          printf 'Date: %s\n' "$RELEASE_DATE"
+          printf '%s\n' "$NOTES"

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           TAGNAME: ${{ github.ref_name }}
         id: split
-        run: echo "version=${TAGNAME##*-v}" >> $GITHUB_OUTPUT
+        run: echo "version=${TAGNAME##*-v}" >> "$GITHUB_OUTPUT"
       - name: Check version against tag
         env:
           TAGVERSION: ${{ steps.split.outputs.version }}

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -56,17 +56,18 @@ jobs:
           version: latest
           changelog: ./package-sets/top-level/nixos-branding/nixos-branding-guide/CHANGELOG.md
       - name: Display release info
+        env:
+          VERSION: ${{ steps.query-release-info.outputs.version }}
+          RELEASE_DATE: ${{ steps.query-release-info.outputs.release-date }}
+          NOTES: ${{ steps.query-release-info.outputs.release-notes }}
         run: |
-          echo "Version: ${{ steps.query-release-info.outputs.version }}"
-          echo "Date: ${{ steps.query-release-info.outputs.release-date }}"
-          cat <<'EOF'
-          "${{ steps.query-release-info.outputs.release-notes }}"
-          EOF
+          printf 'Version: %s\n' "$VERSION"
+          printf 'Date: %s\n' "$RELEASE_DATE"
+          printf '%s\n' "$NOTES"
       - name: Release notes to file
-        run: |
-          cat <<'EOF' > release
-          "${{ steps.query-release-info.outputs.release-notes }}"
-          EOF
+        env:
+          NOTES: ${{ steps.query-release-info.outputs.release-notes }}
+        run: printf '%s\n' "$NOTES" > release
       - name: Release
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
## Problem

The release and check workflows interpolated changelog outputs
(`release-notes`, `version`, `release-date`) directly into `run:` script text
via `${{ }}`. That substitution happens before bash runs, so a changelog line
reading `EOF` could terminate the heredoc early and run the remaining lines as
shell — arbitrary command execution in the release job, which holds
`contents: write`.

## Fix

Pass the outputs through the step `env:` block and reference them as quoted
shell variables (`printf '%s\n' "$NOTES"`), so bash treats them as data, not
code. Applied to both affected steps in `release-guide.yml` and the matching
step in `check.yml`. Also removes the stray quotes that previously wrapped the
release body, and quotes `$GITHUB_OUTPUT` in the version-split step (SC2086).

Both workflows pass `actionlint`.
