### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -13,8 +13,8 @@ description: |
 runs:
   using: 'composite'
   steps:
-    - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3          # was v31
-    - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a     # was v6
+    - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+    - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a  # v6.1.3
       with:
         primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - "/"
+      # Also scan composite actions under .github/actions/*. A plain
+      # "/" does not cover action.yml files, so their pinned actions
+      # would otherwise never be updated.
+      # https://github.com/dependabot/dependabot-core/issues/6704
+      - "/.github/actions/*"
     schedule:
       interval: weekly
     # Dependabot updates both tag-pinned and SHA-pinned action

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,14 +25,14 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: ./.github/actions/setup-nix
       - run: nix flake check --print-build-logs
 
   build-the-world:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: ./.github/actions/setup-nix
       - run: nix run .#nixos-branding.verification.verify-nixos-branding-all --print-build-logs
 
@@ -51,7 +51,7 @@ jobs:
       after: ${{ steps.refs.outputs.after }}
       report-url: ${{ steps.artifact_report.outputs.artifact-url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-nix
@@ -89,13 +89,13 @@ jobs:
             --context 3
 
       - id: artifact_report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: comparison_report
           path: comparison_report.html
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: comparison_summary
           path: comparison_summary.json
@@ -111,7 +111,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: comparison_summary
 
@@ -131,7 +131,7 @@ jobs:
                     comparison_summary.json)
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
 
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0   # was v2
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:
           # The action's action.yml does not provide a default for this
           # input on the pinned SHA, so the workflow must pass the token
@@ -158,10 +158,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Get latest or unreleased info
         id: query-release-info
-        uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32   # was v3.0.0
+        uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32  # v3.0.0
         with:
           command: query
           version: latest-or-unreleased

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
       - name: Build Deployed Assets
         run: |
           nix build .\#nixos-branding.deployed-assets \
@@ -21,7 +21,7 @@ jobs:
           mkdir --parents ./build
           cp --recursive --dereference ./result-deploy/* ./build
       - name: 'Publish to Netlify'
-        uses: 'nwtgck/actions-netlify@v4.0.0'
+        uses: nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668  # v4.0.0
         env:
           NETLIFY_AUTH_TOKEN: '${{ secrets.NETLIFY_AUTH_TOKEN }}'
           NETLIFY_SITE_ID: '${{ secrets.NETLIFY_SITE_ID }}'

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
       - name: Split tag name at version
         env:
           TAGNAME: ${{ github.ref_name }}
@@ -50,7 +50,7 @@ jobs:
             --out-link result-media-kit
       - name: Get latest release info
         id: query-release-info
-        uses: release-flow/keep-a-changelog-action@v3
+        uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32  # v3.0.0
         with:
           command: query
           version: latest
@@ -69,7 +69,7 @@ jobs:
           NOTES: ${{ steps.query-release-info.outputs.release-notes }}
         run: printf '%s\n' "$NOTES" > release
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           name: "NixOS Branding Guide v${{ steps.split.outputs.version }}"
           body_path: release

--- a/.github/workflows/release-npm-package.yaml
+++ b/.github/workflows/release-npm-package.yaml
@@ -13,13 +13,13 @@ jobs:
   build-npm-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "latest"
           registry-url: "https://registry.npmjs.org"
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
       - name: Build npm package
         run: |
           nix build .\#nixos-branding.npm-package \


### PR DESCRIPTION
## What

Pins every external GitHub Actions reference to a full-length commit SHA, each annotated with a standard `# vX.Y.Z` version comment. Resolves all `unpinned-uses` findings from zizmor (19 → 0).

Covered:
- All four workflows: `check.yml`, `release-guide.yml`, `netlify-deploy.yml`, `release-npm-package.yaml`
- The `setup-nix` composite action

Also in this PR:
- Normalized the four references that were already SHA-pinned from the non-standard `# was vN` comment to the standard `# vX.Y.Z` form.
- Corrected `marocchino/sticky-pull-request-comment`: its pinned SHA is actually `v3.0.4`, but it was labeled `# was v2`.
- Updated `.github/dependabot.yml` so the composite action is covered too (see below).

Each SHA was resolved from the tag it was previously pinned to, so the running versions are unchanged. Every pin was verified with `pinact --check` and by independently re-resolving each SHA from its version tag.

## Why

A version tag like `@v7` is mutable — the action owner (or an attacker who compromises the action's repository or account) can repoint it to different code. Pinning to a commit SHA makes each reference immutable.

## Dependabot

Dependabot updates SHA-pinned actions (it bumps both the SHA and the version comment), so these stay maintained automatically.

A plain `directory: "/"` config does not scan composite `action.yml` files ([dependabot-core#6704](https://github.com/dependabot/dependabot-core/issues/6704)). This PR works around that by switching `.github/dependabot.yml` to the `directories:` form with a `/.github/actions/*` glob, so the two actions in `setup-nix/action.yml` are updated too.

## Verification

- `actionlint`: clean
- `zizmor`: `unpinned-uses` 19 → 0 (the remaining zizmor findings are pre-existing and out of scope for this PR)
