### PR TITLE
Harden workflows: env-var PR refs and disable checkout credential persistence

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,11 +59,12 @@ jobs:
       - name: Resolve refs
         id: refs
         shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          MERGE_SHA="${{ github.event.pull_request.merge_commit_sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           # fetch-depth: 0 already pulled base + all reachable refs.
           # Only the merge commit needs an explicit fetch because it
@@ -80,10 +81,13 @@ jobs:
           echo "after=$AFTER_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Compare artifacts
+        env:
+          BEFORE: ${{ steps.refs.outputs.before }}
+          AFTER: ${{ steps.refs.outputs.after }}
         run: |
           nix run .#nixos-branding.verification.compare-artifacts -- \
-            "${{ steps.refs.outputs.before }}" \
-            "${{ steps.refs.outputs.after }}" \
+            "$BEFORE" \
+            "$AFTER" \
             --output comparison_report.html \
             --summary comparison_summary.json \
             --context 3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-nix
       - run: nix flake check --print-build-logs
 
@@ -33,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-nix
       - run: nix run .#nixos-branding.verification.verify-nixos-branding-all --print-build-logs
 
@@ -54,6 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/setup-nix
 
       - name: Resolve refs
@@ -163,6 +168,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Get latest or unreleased info
         id: query-release-info
         uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32  # v3.0.0

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
       - name: Build Deployed Assets

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
       - name: Split tag name at version

--- a/.github/workflows/release-npm-package.yaml
+++ b/.github/workflows/release-npm-package.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "latest"


### PR DESCRIPTION
## What

The injection/token-hardening half of the zizmor cleanup (the SHA-pinning half landed in #55), in two commits:

1. **Template injection (`check.yml`)** — the `Resolve refs` and `Compare artifacts` steps interpolated `github.event.pull_request.*.sha` and the derived step outputs straight into their `run:` scripts. Moved them into `env:` blocks referenced as quoted shell variables. The values are git SHAs, so the real risk was low, but this removes the injection sink and matches the pattern used for the changelog fix.
2. **Credential persistence — `artipacked`** — added `persist-credentials: false` to every `actions/checkout` (7 across the four workflows). None of them push or use git credentials in a later step, so there's no reason to leave the token in `.git/config`.

## Why

Both reduce what a compromised step could reach: no `${{ }}` reaching a shell as code, and no reusable token left on disk.

## Notes

- The one `git fetch` (in `Resolve refs`) targets this public repo, so it works fine without the persisted credential.
- `persist-credentials: false` does not affect the initial checkout — the action still uses its token to clone; it just doesn't write it into `.git/config` for later steps.

## Verification

- `actionlint`: clean
- `zizmor`: `template-injection` and `artipacked` findings both 0 (were 3 and 7). Remaining findings are the `excessive-permissions` set, which is the separate permissions-hardening PR.
