### PR TITLE
Fix release: build release-assets and publish via gh CLI

### DIFF
--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -40,16 +40,11 @@ jobs:
             echo "NixOS Branding Guide tag version and file version DO NOT match"
             exit 1
           fi
-      - name: Build Guide
+      - name: Build release assets
         run: |
-          nix build .\#nixos-branding.nixos-branding-guide \
+          nix build .\#nixos-branding.release-assets \
             --print-build-logs \
-            --out-link result-guide
-      - name: Build Media Kit
-        run: |
-          nix build .\#nixos-branding.nixos-media-kit \
-            --print-build-logs \
-            --out-link result-media-kit
+            --out-link result-assets
       - name: Get latest release info
         id: query-release-info
         uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32  # v3.0.0
@@ -71,15 +66,16 @@ jobs:
           NOTES: ${{ steps.query-release-info.outputs.release-notes }}
         run: printf '%s\n' "$NOTES" > release
       - name: Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
-        with:
-          name: "NixOS Branding Guide v${{ steps.split.outputs.version }}"
-          body_path: release
-          files: |
-            result-guide/*
-            result-media-kit/*
-          make_latest: true
-          overwrite_files: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.split.outputs.version }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "NixOS Branding Guide v$VERSION" \
+            --notes-file release \
+            --latest \
+            --verify-tag \
+            result-assets/*
 
   deploy:
     uses: ./.github/workflows/netlify-deploy.yml

--- a/package-sets/top-level/nixos-branding/release-assets/package.nix
+++ b/package-sets/top-level/nixos-branding/release-assets/package.nix
@@ -1,0 +1,32 @@
+{
+  artifacts,
+  lib,
+  nixos-branding-guide,
+  symlinkJoin,
+}:
+
+let
+
+  inherit (lib.attrsets)
+    attrValues
+    ;
+
+  inherit (lib.nixos-branding)
+    removeDirectoriesRecursiveAttrs
+    ;
+
+in
+
+# Assets attached to a GitHub release: the branding guide document plus the
+# public-facing logos (artifacts.media-kit), flattened into one directory.
+# This matches the pre-removal release contents (the old nixos-branding-guide
+# + nixos-media-kit uploads) in a single buildable package. It deliberately
+# excludes the internal logos and the browsable index.html files that
+# deployed-assets adds for the Netlify web deploy.
+symlinkJoin {
+  name = "release-assets";
+  paths = [
+    nixos-branding-guide
+  ]
+  ++ attrValues (removeDirectoriesRecursiveAttrs artifacts.media-kit);
+}


### PR DESCRIPTION
## What

Fixes the release workflow and finishes the zizmor cleanup, in one PR:

1. **New `release-assets` package** — one derivation bundling the branding guide PDF + the public media-kit logos, flattened. Restores the content of the `nixos-media-kit` package (removed in `b1e12e2`) combined with the guide.
2. **Release job rewired** — builds `release-assets` (one build step instead of two) and publishes with `gh release create` instead of `softprops/action-gh-release`.

## Why

- The release job built `.#nixos-branding.nixos-media-kit`, which was removed in `b1e12e2` ("nixos-branding.nixos-media-kit: remove"). That attribute no longer exists, so the release workflow has been broken at "Build Media Kit" ever since — this restores a working release.
- Dropping the third-party release action clears zizmor's `superfluous-actions` finding and removes third-party code from the `contents: write` release job.
- `gh release create` fails if the release already exists (no accidental overwrite) and fails if a file glob matches nothing (fail loudly on a missing artifact) — both are the behavior we want.

## Parity

Release-asset content is unchanged from before the media-kit removal: the guide PDF + the 52 public logos, flat. Verified by building `release-assets` and diffing its file set against `deployed-assets` — identical to `documents` + `logos`, excluding `internals` and the generated `index.html`.

## Verification

- Built `release-assets`: guide PDF + 52 public logo SVGs
- `nix flake check`: pass
- `actionlint`: clean
- `zizmor`: `superfluous-actions` cleared. The only remaining findings are the `excessive-permissions` set (the separate permissions-hardening PR).

## Note

`gh release create` fails if a release for the tag already exists (intentional — avoids overwriting a published release). A re-run after a partial failure requires deleting the release first.
