### PR TITLE
Scope workflow GITHUB_TOKEN permissions per job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,8 @@ concurrency:
   group: check-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   format:

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -5,6 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  statuses: write
+  deployments: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -6,16 +6,19 @@ on:
     tags:
       - "nixos-branding-guide-v*.*.*"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   check:
     uses: ./.github/workflows/check.yml
+    permissions:
+      contents: read
 
   release:
     needs: check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -80,7 +83,14 @@ jobs:
   deploy:
     uses: ./.github/workflows/netlify-deploy.yml
     needs: release
+    permissions:
+      contents: write
+      statuses: write
+      deployments: write
 
   release-npm-package:
     uses: ./.github/workflows/release-npm-package.yaml
     needs: release
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
## What

Scopes the `GITHUB_TOKEN` permissions across the workflows — the last of the zizmor findings.

- **`check.yml`**: `read-all` → `contents: read` (the two jobs needing more already declare their own blocks).
- **`release-guide.yml`**: top-level `contents: write` → `{}`, granted per job:
  - `release` → `contents: write` (`gh release create`)
  - `check` → `contents: read`
  - `release-npm-package` → `id-token: write` + `contents: read` (npm OIDC)
  - `deploy` → `contents: write` + `statuses: write` + `deployments: write` (Netlify commit-comment / commit-status / GitHub-deployment integrations)
- **`netlify-deploy.yml`**: explicit `permissions` block matching those integrations, so it is scoped on both the release and manual (`workflow_dispatch`) paths.

## Why

The workflow-wide `contents: write` and `read-all` gave every job more access than it needs. A reusable workflow's token is set by the **caller** and can only be reduced, so each calling job now grants exactly its callee's need — notably `id-token: write` for the npm OIDC publish must sit on the calling job ([reuse-workflows docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)).

The Netlify deploy keeps its three GitHub integrations (commit comment, commit status, and a `production` deployment record — all pointing at `brand.nixos.org`), so its job retains `contents`/`statuses`/`deployments: write`, now scoped to that one job instead of the whole workflow.

## Verification

- `actionlint`: clean
- `zizmor`: **0 findings**. This clears the `excessive-permissions` set; earlier PRs cleared unpinned-uses, template-injection, artipacked, and superfluous-actions.

## Not verified

Permissions only take effect at runtime on privileged events — an actual tag-push release and a manual Netlify deploy — which can't be exercised locally. On the next release, watch the npm OIDC publish (`id-token: write` on the calling job) and the Netlify integrations (`contents`/`statuses`/`deployments: write`).
