### PR TITLE
Add workflow-security CI gate (zizmor + pinact) and Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,10 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: weekly
+    cooldown:
+      # Wait this many days before opening an update PR for a freshly
+      # published release, so a compromised release has time to be caught
+      # and yanked before it is auto-adopted (zizmor dependabot-cooldown).
+      default-days: 7
     # Dependabot updates both tag-pinned and SHA-pinned action
     # references. PRs from Dependabot follow normal review.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -188,3 +188,20 @@ jobs:
           printf 'Version: %s\n' "$VERSION"
           printf 'Date: %s\n' "$RELEASE_DATE"
           printf '%s\n' "$NOTES"
+
+  workflow-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+      - name: Audit workflows with zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: nix run .#zizmor -- .github/
+      - name: Verify action pins and version comments with pinact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: nix run .#pinact -- run --check


### PR DESCRIPTION
## What

Adds a CI gate that runs zizmor + pinact over `.github/` on every PR and push, plus a Dependabot cooldown. This is the guardrail for the workflow-hardening series (#55, #58, #59, #60) — it keeps those fixes from silently regressing.

- **`check.yml`** — new `workflow-security` job:
  - `nix run .#zizmor -- .github/` — audits all workflows, the composite action, and `dependabot.yml`.
  - `nix run .#pinact -- run --check` — verifies every action is SHA-pinned and its `# vX.Y.Z` comment matches the SHA.
- **`dependabot.yml`** — `cooldown: { default-days: 7 }`: delays adopting a freshly published release for 7 days so a compromised release can be caught/yanked first.

## Why

The hardening PRs fixed these by hand; without a gate a future PR could reintroduce an unpinned action, a `${{ }}` shell injection, an over-broad permission, or drifted pins. zizmor + pinact catch all of those in CI.

## Notes

- zizmor runs **online** (keeps the `known-vulnerable-actions` CVE check). CI uses only the pinned version with a fresh HTTP cache, so it's reliable; the sole dependency is GitHub API reachability at run time.
- The flake-pinned zizmor (1.18.0) predates the `dependabot-cooldown` audit, so the gate doesn't yet *enforce* the cooldown — the fix is proactive and will be enforced once `flake.lock`'s nixpkgs is next bumped.

## Verification

- `actionlint`: clean
- `nix run .#zizmor -- .github/` (pinned 1.18.0, online): exit 0, no findings
- `nix run .#pinact -- run --check` (pinned 3.4.5): exit 0
- `dependabot.yml`: valid YAML
