### PR TITLE
Resolve zizmor --pedantic findings and add report-only pedantic audit

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,7 @@ permissions:
 
 jobs:
   format:
+    name: Flake check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -33,6 +34,7 @@ jobs:
       - run: nix flake check --print-build-logs
 
   build-the-world:
+    name: Build all artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -42,6 +44,7 @@ jobs:
       - run: nix run .#nixos-branding.verification.verify-nixos-branding-all --print-build-logs
 
   compare-artifacts-build:
+    name: Build artifact comparison
     runs-on: ubuntu-latest
     needs: build-the-world
     if: github.event_name == 'pull_request'
@@ -112,6 +115,7 @@ jobs:
           if-no-files-found: error
 
   compare-artifacts-comment:
+    name: Comment artifact comparison
     runs-on: ubuntu-latest
     needs: compare-artifacts-build
     # Skip on fork PRs (read-only token can't post). Also implicitly
@@ -119,7 +123,7 @@ jobs:
     # itself is gated to those.
     if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
-      pull-requests: write
+      pull-requests: write # post the artifact-comparison sticky comment
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -165,6 +169,7 @@ jobs:
             </details>
 
   branding-guide-changelog:
+    name: Changelog query
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -190,6 +195,7 @@ jobs:
           printf '%s\n' "$NOTES"
 
   workflow-security:
+    name: Workflow security
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -5,6 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  # Never interrupt an in-progress deploy; queue the next run instead.
+  group: netlify-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -5,14 +5,16 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  statuses: write
-  deployments: write
+permissions: {}
 
 jobs:
   deploy:
+    name: Deploy media kit to Netlify
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Netlify action posts a commit comment
+      statuses: write # Netlify action sets a commit status
+      deployments: write # Netlify action creates a GitHub deployment
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - "nixos-branding-guide-v*.*.*"
 
+concurrency:
+  # Serialize release runs for a tag; never interrupt a release in progress.
+  group: release-guide-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -15,10 +15,11 @@ jobs:
       contents: read
 
   release:
+    name: Create GitHub release
     needs: check
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # gh release create publishes the release
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -84,13 +85,13 @@ jobs:
     uses: ./.github/workflows/netlify-deploy.yml
     needs: release
     permissions:
-      contents: write
-      statuses: write
-      deployments: write
+      contents: write # Netlify action posts a commit comment
+      statuses: write # Netlify action sets a commit status
+      deployments: write # Netlify action creates a GitHub deployment
 
   release-npm-package:
     uses: ./.github/workflows/release-npm-package.yaml
     needs: release
     permissions:
-      id-token: write
+      id-token: write # OIDC for npm provenance publish
       contents: read

--- a/.github/workflows/release-npm-package.yaml
+++ b/.github/workflows/release-npm-package.yaml
@@ -5,6 +5,11 @@ on:
   workflow_call:
   workflow_dispatch:
 
+concurrency:
+  # Never interrupt an in-progress publish; queue the next run instead.
+  group: release-npm-package-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/release-npm-package.yaml
+++ b/.github/workflows/release-npm-package.yaml
@@ -5,13 +5,15 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: read
+permissions: {}
 
 jobs:
   build-npm-package:
+    name: Build and publish npm package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,44 @@
+name: Workflow security report
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+      - flake.lock
+  pull_request:
+    paths:
+      - ".github/**"
+      - flake.lock
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor pedantic audit (report-only)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      security-events: write # upload the SARIF report to code scanning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-nix
+      - name: Run zizmor (pedantic, SARIF)
+        # SARIF mode exits 0 even with findings, so this reports rather than
+        # blocks; the blocking gate is the regular-persona run in check.yml.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: nix run .#zizmor -- --format sarif --pedantic . > results.sarif
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a  # v4.36.3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## What

Makes the workflows clean under `zizmor --pedantic` (21 findings → 0) and adds a report-only pedantic audit. Three commits:

1. **Zero-behavior-change fixes:**
   - `excessive-permissions`: moved the workflow-level `permissions` in `netlify-deploy.yml` and `release-npm-package.yaml` down to their single job — identical effective permissions (the caller still sets the ceiling).
   - `undocumented-permissions`: added an explanatory comment to every write permission.
   - `anonymous-definition`: gave every job a `name:`.
2. **Concurrency** (the one behavior change): added a `concurrency` group to `release-guide.yml`, `netlify-deploy.yml`, and `release-npm-package.yaml` with `cancel-in-progress: false` — overlapping runs queue rather than interrupting an in-progress release/deploy/publish. (`check.yml` already had concurrency.)
3. **Report-only pedantic audit:** new `.github/workflows/zizmor.yml` (modeled on NixOS/infra) running `zizmor --pedantic --format sarif` → `codeql-action/upload-sarif`. SARIF mode exits 0, so it is **non-blocking** — pedantic findings appear as PR annotations and in the Security tab. The blocking gate stays the regular-persona run in `check.yml` (from #61).

## Design

A required gate should block on high-confidence findings and *report* opinionated ones:
- **check.yml** (regular persona) blocks on real issues — unchanged.
- **zizmor.yml** (pedantic) reports the opinionated smells without blocking, so a legitimate change isn't stopped by an opinion.

## Verification

- `zizmor --pedantic .github/`: **0 findings** (was 21)
- `zizmor .github/` (regular gate): 0 findings
- `pinact run --check`: clean (incl. the new `upload-sarif` pin)
- `actionlint`: clean
- The pedantic SARIF run produces valid SARIF with 0 findings (a clean baseline)

## Notes

- zizmor comes from the flake's pinned nixpkgs (`.#zizmor`, 1.18.0). infra runs a newer zizmor via a `nixpkgs-unstable` input; adding that later would modernize the audit set (and start reporting `dependabot-cooldown`).
- SARIF upload needs `security-events: write`, which fork PRs don't get — so the upload step won't run on fork PRs (same limitation as infra). It's non-blocking, so that's cosmetic.
- The report only *catches* regressions if the Security tab is reviewed; real regressions remain hard-blocked by `check.yml`.
