### PR TITLE
Attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release-guide.yml
+++ b/.github/workflows/release-guide.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # gh release create publishes the release
+      id-token: write # sign the build-provenance attestation via OIDC
+      attestations: write # write the build-provenance attestation
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -54,6 +56,10 @@ jobs:
           nix build .\#nixos-branding.release-assets \
             --print-build-logs \
             --out-link result-assets
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+        with:
+          subject-path: result-assets/*
       - name: Get latest release info
         id: query-release-info
         uses: release-flow/keep-a-changelog-action@74931dec7ecdbfc8e38ac9ae7e8dd84c08db2f32  # v3.0.0


### PR DESCRIPTION
## What

Adds a signed build-provenance attestation for the GitHub **release** artifacts (the branding guide PDF + the public logos in `result-assets`), using GitHub's official `actions/attest-build-provenance`.

- New `Attest build provenance` step in the `release` job, right after building `result-assets`.
- Grants the `release` job `id-token: write` + `attestations: write` (scoped to that job, alongside the existing `contents: write`).

## Why

The npm package already gets provenance via npm trusted publishing (OIDC); this closes the same gap for the **GitHub release** channel. After a release, anyone can verify an artifact came from this repo's workflow:

```
gh attestation verify <artifact> -R NixOS/branding
```

It's GitHub-native (Sigstore-backed) — no third-party service.

## Verification

- `actionlint`: clean
- `pinact run --check`: clean (new `attest-build-provenance` pinned to `v4.1.1` / `0f67c3f…`)
- `zizmor .github/` (regular gate): 0 findings
- `zizmor --pedantic .github/`: 0 findings

## Not verified

The step only runs on an actual tag-push release, which can't be exercised locally. `subject-path: result-assets/*` globs the built artifacts (symlinks into the Nix store — the same paths `gh release create` already uploads); worth confirming on the next release that it produces attestations for the expected files.
