### PR TITLE
media-kit: add disability pride colored variants of the nix logo

### DIFF
--- a/package-sets/python-packages/nixoslogo/nixoslogo/core.py
+++ b/package-sets/python-packages/nixoslogo/nixoslogo/core.py
@@ -90,6 +90,7 @@ with open(get_nixos_color_palette_file(), "rb") as f:
 PALETTE_DEFAULT_COLORS = NIXOS_COLOR_PALETTE["logos"]["default"]
 PALETTE_RAINBOW_COLORS = NIXOS_COLOR_PALETTE["logos"]["rainbow"]
 PALETTE_TRANS_COLORS = NIXOS_COLOR_PALETTE["logos"]["trans"]
+PALETTE_DISABILITY_COLORS = NIXOS_COLOR_PALETTE["logos"]["disability"]
 PALETTE_PRIMARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["primary"]
 PALETTE_SECONDARY_COLORS = NIXOS_COLOR_PALETTE["palette"]["secondary"]
 PALETTE_ACCENT_COLORS = NIXOS_COLOR_PALETTE["palette"]["accent"]
@@ -112,6 +113,12 @@ TRANS_COLORS = tuple(
     map(
         lambda color: Color("oklch", color["value"]),
         PALETTE_TRANS_COLORS,
+    )
+)
+DISABILITY_COLORS = tuple(
+    map(
+        lambda color: Color("oklch", color["value"]),
+        PALETTE_DISABILITY_COLORS,
     )
 )
 
@@ -149,6 +156,7 @@ class LogomarkColors(Enum):
     DEFAULT = (NIXOS_DARK_BLUE, NIXOS_LIGHT_BLUE)
     RAINBOW = RAINBOW_COLORS
     TRANS = TRANS_COLORS
+    DISABILITY = DISABILITY_COLORS
     BLACK = (NIXOS_BLACK,)
     WHITE = (NIXOS_WHITE,)
 

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-horizontal-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-horizontal-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-horizontal-none";
+  outputHash = "sha256-U//ZxhMg1QqIBw3il+28CCorT9rUpL+4KifxtZyqlWI=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-horizontal-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-horizontal-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-vertical-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-vertical-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-vertical-none";
+  outputHash = "sha256-d8g2St148JRxYgbGI7hCMUliicDnv+kvYFzQ8b6szOQ=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-vertical-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logo-disability-gradient-white-regular-vertical-none/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.NONE,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-flat-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-flat-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-flat-none";
+  outputHash = "sha256-A626ADmhRdhVu+5BxfL6li8pWAaj2prlw9mfFIFcC98=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-flat-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-flat-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-gradient-none/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-gradient-none/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-gradient-none";
+  outputHash = "sha256-7U6PBkfhOYpHRrEE2Krdwajx9U9OaB1UxEzvdj8Ixvs=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-gradient-none/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/internal/nixos-logomark-disability-gradient-none/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.NONE,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-horizontal-minimal";
+  outputHash = "sha256-IRbP6R5ZVhjabAqnUeFXSHqDBG8PsVLV7mj6Ig007io=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-horizontal-recommended";
+  outputHash = "sha256-sdqlNx7YoE+HnJjBOlpqoDZyGUdb2r5tLW1gWpxewjU=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-horizontal-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS_WITH_BEARING,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.HORIZONTAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-vertical-minimal";
+  outputHash = "sha256-TQQJknph7Sm4qSshsKu9HwNZY2uMIn8dCLTWf5HG61s=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-minimal/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.MINIMAL,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logo-disability-gradient-white-regular-vertical-recommended";
+  outputHash = "sha256-oIk8eLD+4ucgY2EgStnEAJ4qOJMLLHhkD0LeXFK6M10=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logo-disability-gradient-white-regular-vertical-recommended/script.py
@@ -1,0 +1,21 @@
+from nixoslogo.core import (
+    DEFAULT_LOGOTYPE_SPACINGS,
+    ClearSpace,
+    ColorStyle,
+    LogoLayout,
+    LogomarkColors,
+    LogotypeStyle,
+)
+from nixoslogo.logo import NixosLogo
+
+logo = NixosLogo(
+    logomark_colors=LogomarkColors.DISABILITY,
+    logomark_color_style=ColorStyle.GRADIENT,
+    logotype_color="white",
+    logotype_style=LogotypeStyle.REGULAR,
+    logotype_spacings=DEFAULT_LOGOTYPE_SPACINGS,
+    logotype_characters="NixOS",
+    logo_layout=LogoLayout.VERTICAL,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logo.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-flat-minimal";
+  outputHash = "sha256-KqcX8rXbdRlLbLTyIYzWmfRYiZ9VWy72nUnVsOR0fWw=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-flat-recommended";
+  outputHash = "sha256-Eg1CYC7lAUGK/46IGvGObGAhFOf1Dj9QaSh8NMypIx0=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-flat-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.FLAT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-minimal/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-minimal/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-gradient-minimal";
+  outputHash = "sha256-pectiKnHObQx4rybfemzXYnEHltx6uJth3OHOVX4jXA=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-minimal/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-minimal/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.MINIMAL,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-recommended/package.nix
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-recommended/package.nix
@@ -1,0 +1,6 @@
+{ artifact-builder }:
+artifact-builder {
+  name = "nixos-logomark-disability-gradient-recommended";
+  outputHash = "sha256-uSmiHKzSaPPwRcgMDXxI19JqXGIUrqTZKGuLfz+/2yA=";
+  script = ./script.py;
+}

--- a/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-recommended/script.py
+++ b/package-sets/top-level/nixos-branding/artifacts/media-kit/nixos-logomark-disability-gradient-recommended/script.py
@@ -1,0 +1,11 @@
+from nixoslogo.core import ClearSpace, ColorStyle, LogomarkColors
+from nixoslogo.logomark import Lambda, Logomark
+
+ilambda = Lambda()
+logomark = Logomark(
+    ilambda=ilambda,
+    colors=LogomarkColors.DISABILITY,
+    color_style=ColorStyle.GRADIENT,
+    clear_space=ClearSpace.RECOMMENDED,
+)
+logomark.write_svg()

--- a/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
+++ b/package-sets/top-level/nixos-branding/nixos-color-palette/colors.toml
@@ -45,6 +45,30 @@ value = [1, 0, 0]
 name = "blue"
 value = [0.8025, 0.12028, 226.51]
 
+[[logos.disability]]
+name = "gray"
+value = [0.3562, 0, 0]
+
+[[logos.disability]]
+name = "pink"
+value = [0.6489, 0.1165, 11.85]
+
+[[logos.disability]]
+name = "yellow"
+value = [0.8426, 0.1088, 86.95]
+
+[[logos.disability]]
+name = "white"
+value = [0.9249, 0, 0]
+
+[[logos.disability]]
+name = "cyan"
+value = [0.7009, 0.1004, 258.62]
+
+[[logos.disability]]
+name = "green"
+value = [0.6655, 0.124, 161.21]
+
 [palette]
 [[palette.primary]]
 name = "Black"


### PR DESCRIPTION
This pull request adds [Disability Pride](https://en.wikipedia.org/wiki/Disability_flag) variants of the Nix logo, inspired by #11. 

<img width="173" height="150" alt="nixos-logomark-disability-gradient-none" src="https://github.com/user-attachments/assets/782c455e-88aa-44ef-9e4f-bcb8b6de8052" />
